### PR TITLE
Fix size display, magnet links, and description links.

### DIFF
--- a/btdig.py
+++ b/btdig.py
@@ -22,6 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 # For more information, please refer to <https://unlicense.org>
 
+import html
 import urllib.parse
 import urllib.request
 import re
@@ -94,10 +95,10 @@ class btdig(object):
             name_match = re.search(r'<div class="torrent_name".*?><a.*?>(.*?)</a>', block_content, re.DOTALL)
             size_match = re.search(r'<span class="torrent_size"[^>]*>(.*?)</span>', block_content)
             
-            desc_link_match = re.search(r'<div class="torrent_name".*?><a href="([^"]+)"', block_content, re.DOTALL) # could implement retrieving further info on torrent later
+            desc_link_match = re.search(r'<div class="torrent_name".*?><a[^>]+href="(https://[^"]+)"', block_content, re.DOTALL) # could implement retrieving further info on torrent later
             
             if magnet_match and name_match and size_match and desc_link_match:
-                result['link'] = magnet_match.group(1)
+                result['link'] = html.unescape(magnet_match.group(1))
                 result['name'] = re.sub(r'<.*?>', '', name_match.group(1)).strip()
                 result['size'] = self._clean_size(size_match.group(1))
                 result['desc_link'] = desc_link_match.group(1)

--- a/btdig.py
+++ b/btdig.py
@@ -99,10 +99,18 @@ class btdig(object):
             if magnet_match and name_match and size_match and desc_link_match:
                 result['link'] = magnet_match.group(1)
                 result['name'] = re.sub(r'<.*?>', '', name_match.group(1)).strip()
-                result['size'] = size_match.group(1).strip().replace('&nbsp;', ' ')
+                result['size'] = self._clean_size(size_match.group(1))
                 result['desc_link'] = desc_link_match.group(1)
                 result['engine_url'] = self.url
                 result['seeds'] = '-1'
                 result['leech'] = '-1'
                 prettyPrinter(result)
 
+    def _clean_size(self, size):
+        # Clean up size - replace problematic characters
+        raw_size = size
+        cleaned_size = raw_size.strip().replace('&nbsp;', ' ')
+        cleaned_size = re.sub(r'[\xa0\u2000-\u200f\u2028-\u202f\u205f\u3000]', ' ', cleaned_size)
+        cleaned_size = re.sub(r'[\x00-\x1f\x7f-\x9f]', '', cleaned_size)
+        cleaned_size = re.sub(r'\s+', ' ', cleaned_size).strip()
+        return cleaned_size


### PR DESCRIPTION
1. Size display in QB was breaking because of unicode characters in the size string. Added a function to clean the string before returning.
2. Magnet links were excluding tracker info. Fixed with HTML unescaping.
3. Description links weren't being properly captured. Fixed regex.